### PR TITLE
Update diagnostic services response to be valid JSON

### DIFF
--- a/web/diagnostic-services/dtc-info.rst
+++ b/web/diagnostic-services/dtc-info.rst
@@ -24,16 +24,16 @@ Response
 
       {
         "code" : {
-          make: 'generic',
-          twoByte: {
-            number: 'P0001',
-            description: 'Fuel Volume Regulator Control Circuit/Open'
+          "make": "generic",
+          "twoByte": {
+            "number": "P0001",
+            "description": "Fuel Volume Regulator Control Circuit/Open"
           },
-          threeByte: {
-            number: 'P0001',
-            ftb: '13',
-            fault: 'Circuit Open',
-            description: 'Fuel Volume Regulator Control'
+          "threeByte": {
+            "number": "P0001",
+            "ftb": "13",
+            "fault": "Circuit Open",
+            "description": "Fuel Volume Regulator Control"
           }
         }
       }


### PR DESCRIPTION
Changed single quotes to double and quoted keys so that documentation renders as valid JSON.
## Previous

> ![Previous](https://cloud.githubusercontent.com/assets/796368/11037286/a1c451e0-86c2-11e5-96c3-f74941312722.png)
## Updated

> ![Updated](https://cloud.githubusercontent.com/assets/796368/11037292/a392d9ce-86c2-11e5-8fa7-1e329cc0b65e.png)
